### PR TITLE
Gumroad import improvements

### DIFF
--- a/src/importers/gumroad.py
+++ b/src/importers/gumroad.py
@@ -213,15 +213,17 @@ def import_posts(import_id, key):
         log(import_id, f"Can't log in; is your session key correct?")
         return
 
+    user_displayname_by_id = {}
     try:
         for user_info_list in scraper_data['creator_counts'].keys():
             parsed_user_info_list = json.loads(user_info_list) # (username, display name, ID), username can be null
             user_id = parsed_user_info_list[2]
+            user_displayname_by_id[user_id] = parsed_user_info_list[1]
             log(import_id, f"Importing posts from user {user_id}")
             import_posts_from_user(import_id, key, parsed_user_info_list)
     finally:
         log(import_id, f"Finished scanning for posts.")
-        index_artists()
+        index_artists(gumroad_name_fallback=user_displayname_by_id)
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:


### PR DESCRIPTION
This fixes problems that can arise during import of a Gumroad library where two different artists share the same display name, and allows importing purchases from stores that have been closed. (Products from closed stores don't have *any* data about the parent creator, so pre-filtering by creator is the only option to associate those with the appropriate creator.)

A fallback for obtaining the Gumroad artist's name is also implemented, since the normal way doesn't work for them (storefront returns 404): when the Gumroad importer finishes, it passes an extra parameter to the `index_artists()` containing a mapping of ID to a display name which can be used to properly name 404'ed stores. Calls to `index_artists()` from other importer threads simply skip these artists without raising exceptions.